### PR TITLE
Remove deprecated usage of .undent

### DIFF
--- a/Formula/s.rb
+++ b/Formula/s.rb
@@ -12,7 +12,7 @@ class S < Formula
     man1.install 's.1'
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<-EOS
     For Bash or Zsh, put something like this in your $HOME/.bashrc or $HOME/.zshrc:
       . `brew --prefix`/etc/profile.d/s.sh
     EOS


### PR DESCRIPTION
Hi @haosdent master!

I was getting errors installing https://github.com/haosdent/s via Homebrew as such:

```sh
$ brew install s
Updating Homebrew...
==> Installing s from haosdent/s
==> Downloading https://github.com/haosdent/s/archive/v1.1.tar.gz
Already downloaded: /Users/limir/Library/Caches/Homebrew/downloads/43f6f4c9b46ba81c08788da3b489a095a6946076a0359700dcfd466009833b3a--s-1.1.tar.gz
Error: undefined method `undent' for #<String:0x0000000103998a50>
Please report this bug:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Taps/haosdent/homebrew-s/Formula/s.rb:18:in `caveats'
/usr/local/Homebrew/Library/Homebrew/caveats.rb:17:in `caveats'
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/2.3.0/forwardable.rb:202:in `empty?'
/usr/local/Homebrew/Library/Homebrew/formula_installer.rb:599:in `caveats'
/usr/local/Homebrew/Library/Homebrew/formula_installer.rb:650:in `finish'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:326:in `install_formula'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:256:in `block in install'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:254:in `each'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:254:in `install'
/usr/local/Homebrew/Library/Homebrew/brew.rb:89:in `<main>'
```

The solution is to replace `EOS.undent` with `EOS` as mentioned here: https://github.com/Homebrew/homebrew-cask/issues/49716#issuecomment-410842187

Orz Orz Orz